### PR TITLE
fix: 处理完杠子之后继续处理可能的四归一(#3)

### DIFF
--- a/mahjong/fan.cpp
+++ b/mahjong/fan.cpp
@@ -346,7 +346,7 @@ void Fan::_CountOverallAttrFan(const Handtiles &ht, const std::vector<Pack> &pac
                 }
             }
             if (flag) { //杠不能算四归一
-                break;
+                continue;
             }
             if (ht.HandTileCount(i) == 4) {
                 _AddFan(FAN_SIGUIYI, {});

--- a/unit_test.cpp
+++ b/unit_test.cpp
@@ -344,6 +344,9 @@ void UnitTest() {
     //独听的处理
     test("[NNN,3]77789m11888p7m|EE0000|", vector<fan_t>{FAN_SIGUIYI, FAN_SHUANGANKE, FAN_YAOJIUKE, FAN_QUEYIMEN});
     test("[NNN,3]78889m11888p8m|EE0000|", vector<fan_t>{FAN_SIGUIYI, FAN_SHUANGTONGKE, FAN_SHUANGANKE, FAN_YAOJIUKE, FAN_QUEYIMEN});
+
+    //杠与四归一的处理
+    test("[1111m][222s,1]78999s44p9s", vector<fan_t>{FAN_SIGUIYI, FAN_SHUANGANKE, FAN_ANGANG, FAN_YAOJIUKE, FAN_YAOJIUKE, FAN_WUZI});
 }
 
 int main() {


### PR DESCRIPTION
在遇到杠子后暂时跳过而不是直接跳出循环。

添加了测试样例并能正确通过所有测试样例：

```
Test case 195: [1111m][222s,1]78999s44p9s, ret = 0
 - ✅  Passed: [string check], Handtiles: 🀫🀇🀇🀫, (🀑)🀑🀑 | 🀖🀗🀘🀘🀘🀜🀜🀘 | 
 - ✅  standard string = [1111m][222s,1]78999s44p9s|EE0000|
 - ✅  Passed: [fan check], count of fan is 9 and fan is:
         四归一  2番
         双暗刻  2番 🀫🀇🀇🀫, 🀘🀘🀘
           暗杠  2番 🀫🀇🀇🀫
         幺九刻  1番 🀫🀇🀇🀫
         幺九刻  1番 🀘🀘🀘
           无字  1番
```